### PR TITLE
Add initial AINUX scaffolding

### DIFF
--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -170,6 +170,7 @@ menu "Pseudo filesystems"
 source "fs/proc/Kconfig"
 source "fs/kernfs/Kconfig"
 source "fs/sysfs/Kconfig"
+source "fs/modelfs/Kconfig"
 
 config TMPFS
 	bool "Tmpfs virtual memory file system support (former shm fs)"

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -123,6 +123,7 @@ obj-$(CONFIG_F2FS_FS)		+= f2fs/
 obj-$(CONFIG_BCACHEFS_FS)	+= bcachefs/
 obj-$(CONFIG_CEPH_FS)		+= ceph/
 obj-$(CONFIG_PSTORE)		+= pstore/
+obj-$(CONFIG_MODELFS)		+= modelfs/
 obj-$(CONFIG_EFIVAR_FS)		+= efivarfs/
 obj-$(CONFIG_EROFS_FS)		+= erofs/
 obj-$(CONFIG_VBOXSF_FS)		+= vboxsf/

--- a/fs/modelfs/Kconfig
+++ b/fs/modelfs/Kconfig
@@ -1,0 +1,4 @@
+config MODELFS
+    bool "Model filesystem"
+    help
+      Pseudo filesystem for signed AI model storage.

--- a/fs/modelfs/Makefile
+++ b/fs/modelfs/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0
+modelfs-objs := inode.o
+obj-\$(CONFIG_MODELFS) += modelfs.o

--- a/fs/modelfs/inode.c
+++ b/fs/modelfs/inode.c
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/pagemap.h>
+#include <linux/magic.h>
+#include <linux/module.h>
+#include <linux/fs_context.h>
+#include <linux/ai_core.h>
+
+#define MODELFS_MAGIC 0x4d4f444c /* 'MODL' */
+
+static char audit_buf[4096];
+static size_t audit_len;
+
+static ssize_t audit_read(struct file *file, char __user *buf, size_t len,
+                         loff_t *ppos)
+{
+    return simple_read_from_buffer(buf, len, ppos, audit_buf, audit_len);
+}
+
+static ssize_t audit_write(struct file *file, const char __user *buf, size_t len,
+                          loff_t *ppos)
+{
+    if (len > sizeof(audit_buf) - audit_len)
+        len = sizeof(audit_buf) - audit_len;
+    if (copy_from_user(audit_buf + audit_len, buf, len))
+        return -EFAULT;
+    audit_len += len;
+    return len;
+}
+
+static const struct file_operations audit_fops = {
+    .read  = audit_read,
+    .write = audit_write,
+    .llseek = default_llseek,
+};
+
+static const struct tree_descr modelfs_files[] = {
+    {"audit.log", &audit_fops, 0644},
+    {"", NULL, 0}
+};
+
+static int modelfs_fill_super(struct super_block *sb, struct fs_context *fc)
+{
+    int err;
+    err = simple_fill_super(sb, MODELFS_MAGIC, modelfs_files);
+    return err;
+}
+
+static int modelfs_get_tree(struct fs_context *fc)
+{
+    return get_tree_single(fc, modelfs_fill_super);
+}
+
+static const struct fs_context_operations modelfs_context_ops = {
+    .get_tree = modelfs_get_tree,
+};
+
+static int modelfs_init_fs_context(struct fs_context *fc)
+{
+    fc->ops = &modelfs_context_ops;
+    return 0;
+}
+
+static struct file_system_type modelfs_fs_type = {
+    .name           = "modelfs",
+    .owner          = THIS_MODULE,
+    .init_fs_context = modelfs_init_fs_context,
+    .kill_sb        = kill_litter_super,
+    .fs_flags       = FS_USERNS_MOUNT,
+};
+MODULE_ALIAS_FS("modelfs");
+
+static int __init init_modelfs(void)
+{
+    return register_filesystem(&modelfs_fs_type);
+}
+module_init(init_modelfs);
+
+static void __exit exit_modelfs(void)
+{
+    unregister_filesystem(&modelfs_fs_type);
+}
+module_exit(exit_modelfs);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("AINUX");
+MODULE_DESCRIPTION("AINUX model filesystem");

--- a/include/linux/ai_core.h
+++ b/include/linux/ai_core.h
@@ -1,0 +1,17 @@
+#ifndef _LINUX_AI_CORE_H
+#define _LINUX_AI_CORE_H
+
+#include <linux/types.h>
+
+struct ai_model {
+    char name[32];
+    void *binary;
+    size_t size;
+    u64 loaded_at;
+};
+
+int ai_model_load(const char *path);
+int ai_model_infer(void *input, void *output);
+int ai_model_unload(const char *name);
+
+#endif /* _LINUX_AI_CORE_H */

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -502,6 +502,7 @@ source "kernel/irq/Kconfig"
 source "kernel/time/Kconfig"
 source "kernel/bpf/Kconfig"
 source "kernel/Kconfig.preempt"
+source "kernel/ai/Kconfig"
 
 menu "CPU/Task time and stats accounting"
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -56,6 +56,7 @@ obj-y += livepatch/
 obj-y += dma/
 obj-y += entry/
 obj-$(CONFIG_MODULES) += module/
+obj-$(CONFIG_AI_CORE) += ai/
 
 obj-$(CONFIG_KCMP) += kcmp.o
 obj-$(CONFIG_FREEZER) += freezer.o

--- a/kernel/ai/Kconfig
+++ b/kernel/ai/Kconfig
@@ -1,0 +1,4 @@
+config AI_CORE
+    bool "AINUX AI core"
+    help
+      Basic AI model management support.

--- a/kernel/ai/Makefile
+++ b/kernel/ai/Makefile
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: GPL-2.0
+obj-$(CONFIG_AI_CORE) += ai_core.o

--- a/kernel/ai/ai_core.c
+++ b/kernel/ai/ai_core.c
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/module.h>
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/timekeeping.h>
+#include <linux/ai_core.h>
+
+static struct ai_model current_model;
+static struct proc_dir_entry *ai_dir;
+static struct proc_dir_entry *ai_model_entry;
+
+static int model_show(struct seq_file *m, void *v)
+{
+    if (!current_model.binary)
+        return 0;
+    seq_printf(m, "model: %s loaded at %llu\n", current_model.name,
+               current_model.loaded_at);
+    return 0;
+}
+
+static int model_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, model_show, NULL);
+}
+
+static const struct proc_ops ai_model_proc_ops = {
+    .proc_open    = model_open,
+    .proc_read    = seq_read,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release,
+};
+
+int ai_model_load(const char *path)
+{
+    strscpy(current_model.name, path, sizeof(current_model.name));
+    current_model.loaded_at = ktime_get_real_seconds();
+    current_model.binary = (void *)0x1; /* placeholder */
+    current_model.size = 0;
+    pr_info("ai_core: model %s loaded\n", current_model.name);
+    return 0;
+}
+EXPORT_SYMBOL_GPL(ai_model_load);
+
+int ai_model_infer(void *input, void *output)
+{
+    return -ENOSYS;
+}
+EXPORT_SYMBOL_GPL(ai_model_infer);
+
+int ai_model_unload(const char *name)
+{
+    memset(&current_model, 0, sizeof(current_model));
+    pr_info("ai_core: model unloaded\n");
+    return 0;
+}
+EXPORT_SYMBOL_GPL(ai_model_unload);
+
+static int __init ai_core_init(void)
+{
+    ai_dir = proc_mkdir("ai", NULL);
+    if (!ai_dir)
+        return -ENOMEM;
+
+    ai_model_entry = proc_create("model", 0444, ai_dir, &ai_model_proc_ops);
+    if (!ai_model_entry)
+        return -ENOMEM;
+
+    pr_info("ai_core initialized\n");
+    return 0;
+}
+module_init(ai_core_init);
+
+static void __exit ai_core_exit(void)
+{
+    proc_remove(ai_model_entry);
+    proc_remove(ai_dir);
+    pr_info("ai_core exit\n");
+}
+module_exit(ai_core_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("AINUX");
+MODULE_DESCRIPTION("AINUX AI core module");

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,7 +15,8 @@ help:
 	@echo '  cpupower               - a tool for all things x86 CPU power'
 	@echo '  debugging              - tools for debugging'
 	@echo '  firewire               - the userspace part of nosy, an IEEE-1394 traffic sniffer'
-	@echo '  firmware               - Firmware tools'
+@echo '  firmware               - Firmware tools'
+@echo '  ainux                  - AINUX AI user tools'
 	@echo '  freefall               - laptop accelerometer program for disk protection'
 	@echo '  gpio                   - GPIO tools'
 	@echo '  hv                     - tools used when in Hyper-V clients'
@@ -70,7 +71,9 @@ cpupower: FORCE
 	$(call descend,power/$@)
 
 counter firewire hv guest bootconfig spi usb virtio mm bpf iio gpio objtool leds wmi firmware debugging tracing: FORCE
-	$(call descend,$@)
+		$(call descend,$@)
+ainux: FORCE
+		$(call descend,$@)
 
 bpf/%: FORCE
 	$(call descend,$@)
@@ -123,10 +126,10 @@ ynl: FORCE
 	$(call descend,net/ynl)
 
 all: acpi counter cpupower gpio hv firewire \
-		perf selftests bootconfig spi turbostat usb \
-		virtio mm bpf x86_energy_perf_policy \
-		tmon freefall iio objtool kvm_stat wmi \
-		debugging tracing thermal thermometer thermal-engine ynl
+                perf selftests bootconfig spi turbostat usb \
+                virtio mm bpf x86_energy_perf_policy \
+                tmon freefall iio objtool kvm_stat wmi ainux \
+                debugging tracing thermal thermometer thermal-engine ynl
 
 acpi_install:
 	$(call descend,power/$(@:_install=),install)
@@ -178,8 +181,11 @@ acpi_clean:
 cpupower_clean:
 	$(call descend,power/cpupower,clean)
 
-counter_clean hv_clean firewire_clean bootconfig_clean spi_clean usb_clean virtio_clean mm_clean wmi_clean bpf_clean iio_clean gpio_clean objtool_clean leds_clean firmware_clean debugging_clean tracing_clean:
+counter_clean hv_clean firewire_clean bootconfig_clean spi_clean usb_clean virtio_clean mm_clean wmi_clean bpf_clean iio_clean gpio_clean objtool_clean leds_clean firmware_clean debugging_clean tracing_clean ainux_clean:
 	$(call descend,$(@:_clean=),clean)
+
+	ainux_clean:
+	$(call descend,ainux,clean)
 
 libapi_clean:
 	$(call descend,lib/api,clean)
@@ -225,11 +231,11 @@ ynl_clean:
 	$(call descend,net/$(@:_clean=),clean)
 
 clean: acpi_clean counter_clean cpupower_clean hv_clean firewire_clean \
-		perf_clean selftests_clean turbostat_clean bootconfig_clean spi_clean usb_clean virtio_clean \
-		mm_clean bpf_clean iio_clean x86_energy_perf_policy_clean tmon_clean \
-		freefall_clean build_clean libbpf_clean libsubcmd_clean \
-		gpio_clean objtool_clean leds_clean wmi_clean firmware_clean debugging_clean \
-		intel-speed-select_clean tracing_clean thermal_clean thermometer_clean thermal-engine_clean \
-		sched_ext_clean ynl_clean
+                perf_clean selftests_clean turbostat_clean bootconfig_clean spi_clean usb_clean virtio_clean \
+                mm_clean bpf_clean iio_clean x86_energy_perf_policy_clean tmon_clean \
+                freefall_clean build_clean libbpf_clean libsubcmd_clean \
+                gpio_clean objtool_clean leds_clean wmi_clean firmware_clean debugging_clean \
+                ainux_clean intel-speed-select_clean tracing_clean thermal_clean thermometer_clean thermal-engine_clean \
+                sched_ext_clean ynl_clean
 
 .PHONY: FORCE

--- a/tools/ainux/Makefile
+++ b/tools/ainux/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0
+HOST_EXTRACFLAGS += -I$(srctree)/tools/include
+hostprogs-y := ainuxd ai-diagnose
+
+include ../../scripts/Makefile.host

--- a/tools/ainux/ai_diagnose.c
+++ b/tools/ainux/ai_diagnose.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+    printf("ai-diagnose summary (mock LLM output)\n");
+    return 0;
+}

--- a/tools/ainux/ainuxd.c
+++ b/tools/ainux/ainuxd.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+    printf("ainuxd starting (gRPC mock)\n");
+    /* TODO: implement gRPC server */
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce `ai_core` kernel module with proc interface
- add simple `modelfs` pseudo filesystem
- create `ainuxd` and `ai-diagnose` user tools
- hook modules into Kconfig and Makefiles

## Testing
- `make -C tools/objtool` (passed)
- `make M=kernel/ai modules`
- `make M=fs/modelfs modules`