### PR TITLE
Add context screen to ai_terminal

### DIFF
--- a/ai_terminal/README.md
+++ b/ai_terminal/README.md
@@ -12,6 +12,7 @@ Features include:
 - Opening a web browser
 - Sending basic email via the local `sendmail`
 - Asking questions about recent terminal errors using OpenAI
+- Viewing the full terminal context with the `show context` command
 
 Set `OPENAI_API_KEY` in your environment for OpenAI integration.
 

--- a/ai_terminal/main.py
+++ b/ai_terminal/main.py
@@ -20,6 +20,15 @@ logging.basicConfig(level=logging.INFO)
 TERMINAL_HISTORY = []
 
 
+def show_context():
+    """Display the recorded terminal history as a context screen."""
+    os.system('clear')
+    print("--- Terminal Context ---")
+    for entry in TERMINAL_HISTORY:
+        print(entry)
+    input("Press Enter to continue...")
+
+
 def listen() -> Optional[str]:
     """Capture voice input using the default microphone."""
     if sr is None:
@@ -98,6 +107,8 @@ def main():
                 to_addr = parts[2]
                 subject = ' '.join(parts[3:])
                 send_email(to_addr, subject, 'Sent from AI terminal')
+        elif 'context screen' in command or command == 'show context':
+            show_context()
         elif 'what is this error' in command:
             answer = ask_openai(command)
             print(answer)


### PR DESCRIPTION
## Summary
- add a `show_context()` helper to display the full terminal history
- accept a `context screen` or `show context` command to open the context view
- document the `show context` command in AI Voice Terminal README

## Testing
- `python -m py_compile ai_terminal/main.py`